### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,8 +14,11 @@ For example
 - Fixed #100500 by adding lenses to exported items
 
 Write 'None' if there are no related issues (which is discouraged).
+Please use keywords to close related issues if they should be closed:
+https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
 -->
-https://github.com/serokell/tezos-client/issues/
+
+Resolves #
 
 #### Related changes (conditional)
 


### PR DESCRIPTION
## Description

Problem: GitHub has special keywords to close an issue when a PR
is merged, but our PR template doesn't encourage their usage.
Most commonly a PR closes an issue, so it makes sense to use a
corresponding keyword.

Solution: update "related issue(s)" section to contain "Resolves"
keyword. Also use just `#` instead of full link to an issue because
it is shorter and more resistant to changes like movement of a repo.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
