### PR TITLE
Change link to CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ to build native `.rpm` or `.deb` package for Red Hat and Debian-based distros.
 ## Obtain binary or packages from CI
 
 If you don't want to build these files from scratch, you can download artifacts
-produced by the CI. Go to the [latest master build](https://buildkite.com/serokell/tezos-client/builds/latest?branch=master),
+produced by the CI. Go to the [latest master build](https://buildkite.com/serokell/tezos-client-packaging/builds/latest?branch=master),
 click on `build and package` stage, choose `Artifacts` section and download files by clcking on the filenames.
 
 ## Ubuntu (Debian based distros) usage


### PR DESCRIPTION

## Description
Problem: Both repo and CI pipeline were renamed, however, README has
link to the old pipeline (it still works, btw).

Solution: Update link to renamed buildkite pipeline.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #3 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
